### PR TITLE
Feat/extract rule based

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,7 +1,9 @@
 import httpx
 from fastapi import FastAPI, HTTPException, Path
 
+from app.schemas.extract import CompanySnapshot
 from app.schemas.ingest import TICKER_PATTERN, IngestRequest, IngestResult
+from app.services.extract import extract_snapshot
 from app.services.ingest import IngestTooLarge, IngestUnsupportedType, fetch_to_disk
 
 app = FastAPI()
@@ -36,3 +38,8 @@ def ingest(
         )
     except httpx.RequestError as e:
         raise HTTPException(status_code=504, detail=f"Network error: {e}")
+
+
+@app.post("/extract/{ticker}", response_model=CompanySnapshot)
+def extract(ticker: str):
+    return extract_snapshot(ticker)

--- a/src/app/schemas/extract.py
+++ b/src/app/schemas/extract.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, Field
+
+
+class Headline(BaseModel):
+    revenue: float = Field(..., description="Total revenue for the quarter")
+    eps_diluted: float = Field(..., description="Diluted EPS")
+
+
+class CompanySnapshot(BaseModel):
+    ticker: str
+    headline: Headline
+    source_path: str

--- a/src/app/services/extract.py
+++ b/src/app/services/extract.py
@@ -22,11 +22,11 @@ def parse_revenue_and_eps(html: str) -> Headline:
     soup = BeautifulSoup(html, "html.parser")
     text = soup.get_text(" ", strip=True)
 
-    # Super naive regex for demo — we’ll refine on real fixtures
-    rev_match = re.search(
-        r"Revenue.*?\$?([\d,]+\.?\d*)\s*(million|billion)?", text, re.I
-    )
-    eps_match = re.search(r"(?:Diluted\s+)?EPS.*?\$?([\d\.]+)", text, re.I)
+    rev_pattern = r"Revenue.*?\$?([\d,\.]+)\s*(billion|million)?"
+    eps_pattern = r"Diluted EPS.*?\$?([\d,\.]+)[,\s]"
+
+    rev_match = re.search(rev_pattern, text, re.IGNORECASE)
+    eps_match = re.search(eps_pattern, text, re.IGNORECASE)
 
     if not rev_match or not eps_match:
         raise HTTPException(status_code=422, detail="Missing revenue or EPS")
@@ -37,7 +37,7 @@ def parse_revenue_and_eps(html: str) -> Headline:
     elif rev_match.group(2) and rev_match.group(2).lower().startswith("m"):
         revenue_val *= 1_000_000
 
-    eps_val = float(eps_match.group(1).replace("$", ""))
+    eps_val = float(eps_match.group(1).replace(",", "").strip())
 
     return Headline(revenue=revenue_val, eps_diluted=eps_val)
 

--- a/src/app/services/extract.py
+++ b/src/app/services/extract.py
@@ -1,0 +1,51 @@
+import re
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from fastapi import HTTPException
+
+from app.config import DATA_DIR
+from app.schemas.extract import CompanySnapshot, Headline
+
+
+def latest_file_for_ticker(ticker: str) -> Path:
+    folder = DATA_DIR / "raw" / ticker.upper()
+    if not folder.exists():
+        raise HTTPException(status_code=404, detail=f"No raw data for {ticker}")
+    candidates = sorted(folder.glob("*.html"), reverse=True)
+    if not candidates:
+        raise HTTPException(status_code=404, detail=f"No HTML files found for {ticker}")
+    return candidates[0]
+
+
+def parse_revenue_and_eps(html: str) -> Headline:
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text(" ", strip=True)
+
+    # Super naive regex for demo — we’ll refine on real fixtures
+    rev_match = re.search(
+        r"\$?([\d,]+\.?\d*)\s+(million|billion)?\s+revenue", text, re.I
+    )
+    eps_match = re.search(r"EPS(?:\s+diluted)?\s+(\$?[\d\.]+)", text, re.I)
+
+    if not rev_match or not eps_match:
+        raise HTTPException(status_code=422, detail="Missing revenue or EPS")
+
+    revenue_val = float(rev_match.group(1).replace(",", ""))
+    if rev_match.group(2) and rev_match.group(2).lower().startswith("b"):
+        revenue_val *= 1_000_000_000
+    elif rev_match.group(2) and rev_match.group(2).lower().startswith("m"):
+        revenue_val *= 1_000_000
+
+    eps_val = float(eps_match.group(1).replace("$", ""))
+
+    return Headline(revenue=revenue_val, eps_diluted=eps_val)
+
+
+def extract_snapshot(ticker: str) -> CompanySnapshot:
+    path = latest_file_for_ticker(ticker)
+    html = path.read_text(errors="ignore")
+    headline = parse_revenue_and_eps(html)
+    return CompanySnapshot(
+        ticker=ticker.upper(), headline=headline, source_path=str(path)
+    )

--- a/src/app/services/extract.py
+++ b/src/app/services/extract.py
@@ -24,9 +24,9 @@ def parse_revenue_and_eps(html: str) -> Headline:
 
     # Super naive regex for demo — we’ll refine on real fixtures
     rev_match = re.search(
-        r"\$?([\d,]+\.?\d*)\s+(million|billion)?\s+revenue", text, re.I
+        r"Revenue.*?\$?([\d,]+\.?\d*)\s*(million|billion)?", text, re.I
     )
-    eps_match = re.search(r"EPS(?:\s+diluted)?\s+(\$?[\d\.]+)", text, re.I)
+    eps_match = re.search(r"(?:Diluted\s+)?EPS.*?\$?([\d\.]+)", text, re.I)
 
     if not rev_match or not eps_match:
         raise HTTPException(status_code=422, detail="Missing revenue or EPS")

--- a/tests/fixtures/missing_eps.html
+++ b/tests/fixtures/missing_eps.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html><body>
+  <p>Revenue of $5.1 billion increased 4%.</p>
+  <!-- EPS intentionally omitted -->
+</body></html>

--- a/tests/fixtures/msft_press.html
+++ b/tests/fixtures/msft_press.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>Microsoft Reports Q4 Results</h1>
+    <p>Revenue of $62.0 billion increased 15% year-over-year.</p>
+    <p>Diluted EPS was $2.94, up 10%.</p>
+  </body>
+</html>

--- a/tests/test_extract_html.py
+++ b/tests/test_extract_html.py
@@ -1,0 +1,47 @@
+import shutil
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import extract as extract_mod
+from app.services.extract import extract_snapshot
+
+
+def _seed_raw_html(tmp_path: Path, ticker: str, fixture_name: str) -> Path:
+    """Copy a fixture into the expected data/raw/{TICKER}/YYYY-MM-DD_*.html spot."""
+    raw_dir = tmp_path / "raw" / ticker
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    src = Path("tests/fixtures") / fixture_name
+    dst = (
+        raw_dir / "2025-01-01_press.html"
+    )  # any name; latest_file_for_ticker will pick it
+    shutil.copyfile(src, dst)
+    return dst
+
+
+def test_extract_from_fixture_html(tmp_path: Path, monkeypatch):
+    # Point the extractor to a temp DATA_DIR
+    extract_mod.DATA_DIR = tmp_path
+
+    # Seed one HTML file for MSFT
+    path = _seed_raw_html(tmp_path, "MSFT", "msft_press.html")
+
+    snap = extract_snapshot("MSFT")
+
+    assert snap.ticker == "MSFT"
+    assert snap.source_path == str(path)
+    # 62.0 billion -> 62_000_000_000.0
+    assert abs(snap.headline.revenue - 62_000_000_000.0) < 1e-6
+    assert abs(snap.headline.eps_diluted - 2.94) < 1e-6
+
+
+def test_extract_422_when_missing_numbers(tmp_path: Path, monkeypatch):
+    extract_mod.DATA_DIR = tmp_path
+    _seed_raw_html(tmp_path, "AAPL", "missing_eps.html")
+
+    with pytest.raises(HTTPException) as exc:
+        extract_snapshot("AAPL")
+
+    assert exc.value.status_code == 422
+    assert "Missing revenue or EPS" in exc.value.detail


### PR DESCRIPTION
This pull request adds a new extraction feature to the API, enabling users to retrieve a structured financial snapshot for a given ticker symbol by parsing stored HTML press releases. It introduces a new endpoint, supporting models and services for parsing, as well as comprehensive tests and fixtures to ensure correctness and error handling. Closes #3 

**API and Feature Additions:**

* Added a new `POST /extract/{ticker}` endpoint to `src/app/main.py` that returns a `CompanySnapshot` containing parsed financial headline data for the specified ticker.
* Implemented the extraction logic in `src/app/services/extract.py`, including functions to locate the latest HTML file for a ticker, parse revenue and EPS values from the HTML, and construct the response model.

**Schema and Model Updates:**

* Introduced new Pydantic models in `src/app/schemas/extract.py`: `Headline` for financial metrics and `CompanySnapshot` for the API response.

**Testing and Fixtures:**

* Added tests in `tests/test_extract_html.py` to verify correct extraction from fixture HTML, including handling of missing data and error responses.
* Created fixture HTML files for both valid and missing EPS cases in `tests/fixtures/msft_press.html` and `tests/fixtures/missing_eps.html`. [[1]](diffhunk://#diff-b5f86602a47d7c5b60c2261b2cf6460bce1d518c68e4b5c6f70c95e3cfaaf034R1-R8) [[2]](diffhunk://#diff-81585c935ede0a1110a117a5b0e6aafa5cef2f80a3995e5e0f3be15de5df86c9R1-R5)