### PR TITLE
Delta Service

### DIFF
--- a/src/app/services/delta.py
+++ b/src/app/services/delta.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from typing import Optional, TypedDict
+
+from app.config import DATA_DIR
+
+
+class Headline(TypedDict, total=False):
+    revenue: float
+    eps_diluted: float
+
+
+class DeltaResult(TypedDict, total=False):
+    revenue_yoy_pct: Optional[float]
+    revenue_qoq_pct: Optional[float]
+    eps_yoy_pct: Optional[float]
+    eps_qoq_pct: Optional[float]
+
+
+def _pct_change(current: Optional[float], prior: Optional[float]) -> Optional[float]:
+    if current is None or prior is None:
+        return None
+    if prior == 0:
+        return None  # avoid div-by-zero; undefined change
+    return round(((current - prior) / prior) * 100.0, 2)
+
+
+def compute_deltas(
+    current: Headline,
+    yoy_baseline: Optional[Headline] = None,
+    qoq_baseline: Optional[Headline] = None,
+) -> DeltaResult:
+    """Compute YoY and QoQ % changes for revenue and EPS."""
+    return {
+        "revenue_yoy_pct": _pct_change(
+            current.get("revenue"), (yoy_baseline or {}).get("revenue")
+        ),
+        "revenue_qoq_pct": _pct_change(
+            current.get("revenue"), (qoq_baseline or {}).get("revenue")
+        ),
+        "eps_yoy_pct": _pct_change(
+            current.get("eps_diluted"), (yoy_baseline or {}).get("eps_diluted")
+        ),
+        "eps_qoq_pct": _pct_change(
+            current.get("eps_diluted"), (qoq_baseline or {}).get("eps_diluted")
+        ),
+    }
+
+
+def load_baseline(ticker: str, kind: str) -> Headline | None:
+    """
+    kind: 'qoq' or 'yoy'. Looks for data/parsed/{ticker}/{kind}_baseline.json
+    """
+    p = DATA_DIR / "parsed" / ticker.upper() / f"{kind}_baseline.json"
+    if not p.exists():
+        return None
+    return json.loads(p.read_text()).get("headline")

--- a/src/app/services/delta.py
+++ b/src/app/services/delta.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import json
-from typing import Optional, TypedDict
+import re
+from typing import Literal, Optional, Pattern, TypedDict
 
 from app.config import DATA_DIR
+from app.schemas.ingest import TICKER_PATTERN
+
+BaselineKind = Literal["qoq", "yoy"]
+
+_TICKER_RE: Pattern[str] = re.compile(TICKER_PATTERN)
 
 
 class Headline(TypedDict, total=False):
@@ -48,10 +54,22 @@ def compute_deltas(
     }
 
 
-def load_baseline(ticker: str, kind: str) -> Headline | None:
+def load_baseline(ticker: str, kind: BaselineKind) -> Headline | None:
+    """Load baseline data for comparing financial metrics.
+
+    Args:
+        ticker: Company stock symbol
+        kind: Type of baseline - "qoq" (quarter-over-quarter) or "yoy" (year-over-year)
+
+    Returns:
+        Headline with baseline metrics or None if not found
+
+    Raises:
+        ValueError: If ticker format is invalid
     """
-    kind: 'qoq' or 'yoy'. Looks for data/parsed/{ticker}/{kind}_baseline.json
-    """
+    if not _TICKER_RE.match(ticker.upper()):
+        raise ValueError(f"Invalid ticker format: {ticker}")
+
     p = DATA_DIR / "parsed" / ticker.upper() / f"{kind}_baseline.json"
     if not p.exists():
         return None

--- a/tests/fixtures/sample_last_quarter.json
+++ b/tests/fixtures/sample_last_quarter.json
@@ -1,0 +1,3 @@
+{
+  "headline": { "revenue": 57500000000.0, "eps_diluted": 2.75 }
+}

--- a/tests/fixtures/sample_last_year.json
+++ b/tests/fixtures/sample_last_year.json
@@ -1,0 +1,3 @@
+{
+  "headline": { "revenue": 54000000000.0, "eps_diluted": 2.40 }
+}

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,0 +1,47 @@
+import json
+
+from app.services.delta import compute_deltas
+
+
+def _load(path: str):
+    with open(path) as f:
+        return json.load(f)["headline"]
+
+
+def test_compute_deltas_happy_path(tmp_path):
+    current = {"revenue": 62_000_000_000.0, "eps_diluted": 2.94}
+    qoq = _load("tests/fixtures/sample_last_quarter.json")
+    yoy = _load("tests/fixtures/sample_last_year.json")
+
+    d = compute_deltas(current, yoy_baseline=yoy, qoq_baseline=qoq)
+
+    # (62 - 54) / 54 = 14.81%
+    assert d["revenue_yoy_pct"] == 14.81
+    # (62 - 57.5) / 57.5 = 7.83%
+    assert d["revenue_qoq_pct"] == 7.83
+    # (2.94 - 2.40) / 2.40 = 22.5%
+    assert d["eps_yoy_pct"] == 22.5
+    # (2.94 - 2.75) / 2.75 = 6.91%
+    assert d["eps_qoq_pct"] == 6.91
+
+
+def test_compute_deltas_handles_zero_and_missing():
+    current = {"revenue": 10.0}
+    qoq = {"revenue": 0.0, "eps_diluted": 0.0}
+    yoy = {"revenue": None, "eps_diluted": 2.0}  # type: ignore
+
+    d = compute_deltas(current, yoy_baseline=yoy, qoq_baseline=qoq)
+
+    # prior 0 => None, missing prior => None, missing current metric => None
+    assert d["revenue_qoq_pct"] is None
+    assert d["revenue_yoy_pct"] is None
+    assert d["eps_qoq_pct"] is None
+    assert d["eps_yoy_pct"] is None
+
+
+def test_negative_delta_rounding():
+    current = {"revenue": 90.0, "eps_diluted": 1.8}
+    qoq = {"revenue": 100.0, "eps_diluted": 2.0}
+    d = compute_deltas(current, qoq_baseline=qoq)
+    assert d["revenue_qoq_pct"] == -10.0
+    assert d["eps_qoq_pct"] == -10.0


### PR DESCRIPTION
This pull request introduces a new service for computing financial metric deltas (year-over-year and quarter-over-quarter percentage changes) and adds corresponding tests and sample data fixtures. The main focus is on reliably calculating and validating percentage changes for revenue and EPS, including handling edge cases like missing or zero baseline values.

**Delta computation service:**

* Added `compute_deltas` function in `src/app/services/delta.py` to calculate YoY and QoQ percentage changes for `revenue` and `eps_diluted`, with robust handling for missing or zero baselines.
* Implemented helper function `_pct_change` for safe percentage calculations, avoiding division by zero and missing data.
* Added `load_baseline` utility to load baseline headline values from JSON files for a given ticker and period kind.

**Testing and fixtures:**

* Created `tests/test_delta.py` with tests covering standard calculations, edge cases (zero/missing data), and negative delta rounding for the new delta computation logic.
* Added sample fixture files `tests/fixtures/sample_last_quarter.json` and `tests/fixtures/sample_last_year.json` to support test scenarios. [[1]](diffhunk://#diff-6e1551ffea259ff38ac8260eea82fe1a8d4524558c9d0ff17651318ee552bb13R1-R3) [[2]](diffhunk://#diff-8e36bc4b10d0ffae79556a35a1d5b35e31f70261f04a29be38d0e94fad8ab0f7R1-R3)…mbers and results.

Closes #4 